### PR TITLE
fix: resolve issue where extension fails when courseIds is an empty array

### DIFF
--- a/src/service_worker/index.ts
+++ b/src/service_worker/index.ts
@@ -47,7 +47,7 @@ function sendMessageToTab(tabId: number, message: any) {
  */
 export async function getCourseIds(tabId: number): Promise<CourseInfo[]> {
   const { courseIds } = await chrome.storage.local.get('courseIds');
-  if (courseIds) {
+  if (courseIds?.length) {
     console.log('[이코] 스토리지에서 courseIds 불러옴');
     return courseIds;
   }


### PR DESCRIPTION
Resolved a bug causing the extension to become completely non-functional when courseIds is stored as an empty array in local storage, potentially due to unknown factors (e.g., script execution prior to page load).
Further investigation is required to determine the root cause of courseIds being saved as an empty array.